### PR TITLE
Modernize CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,48 +1,20 @@
-cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.14 FATAL_ERROR) #FetchContent_MakeAvailable
 project(cs)
 
-#. . . . . . . . . . . . . . . . . . . .
-include(GNUInstallDirs)
-if(MSVC)
-    add_compile_options(/W4)
-    add_link_options(/W4)
-    set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_DEBUG ${CMAKE_BINARY_DIR}/bin)
-    # message("compiler: MSVC")
-else()
-    # message("compiler: NOT MSVC")
-    # add_compile_options(-Wall -Wextra -pedantic -Werror -Wl,--fatal-warnings)
-    set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
-endif()
-
-
-# place binaries and libraries according to GNU standards
-set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR})
-set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR})
-
-
-
-if(CMAKE_CXX_COMPILER_ID MATCHES GNU)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fprofile-arcs -ftest-coverage")
-endif()
-#. . . . . . . . . . . . . . . . . . . .
-
 # ------------------------------------
+find_package(GTest QUIET)
+if (NOT ${GTest_FOUND}) # GTest not found, FetchContent!
 include(FetchContent)
 FetchContent_Declare(
-  googletest
-  URL https://github.com/google/googletest/archive/609281088cfefc76f9d0ce82e1ff6c30cc3591e5.zip
-)
-
-# For Windows: Prevent overriding the parent project's compiler/linker settings
-set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+    googletest
+    GIT_REPOSITORY https://github.com/google/googletest.git
+    GIT_TAG        v1.13.0)
 FetchContent_MakeAvailable(googletest)
-
-# GoogleTest requires at least C++11
-set(CMAKE_CXX_STANDARD 11)
- 
-enable_testing() 
-
-
+endif()
+    
+# GoogleTest requires at least C++14
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
 # ------------------------------------
 
 
@@ -51,10 +23,8 @@ enable_testing()
 #   Grab all cpp files from includes folder
 #- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
 set(INCLUDES_FOLDER includes)
-FILE(GLOB_RECURSE SOURCE_FILES RELATIVE ${CMAKE_CURRENT_SOURCE_DIR}   "${INCLUDES_FOLDER}/*.cpp" )
+FILE(GLOB_RECURSE SOURCE_FILES RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} CONFIGURE_DEPENDS "${INCLUDES_FOLDER}/*.cpp")
 #- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
-
-
 
 ADD_EXECUTABLE(main
     main.cpp
@@ -66,16 +36,10 @@ ADD_EXECUTABLE(basic_test
     ${SOURCE_FILES}
 )
 
-# ADD_EXECUTABLE(testA
-#     _tests/_test_files/testA.cpp
-#     ${SOURCE_FILES}
-# )
-
 ADD_EXECUTABLE(testB
     _tests/_test_files/testB.cpp
     ${SOURCE_FILES}
 )
 
-TARGET_LINK_LIBRARIES(basic_test gtest)
-# TARGET_LINK_LIBRARIES(testA gtest)
-TARGET_LINK_LIBRARIES(testB gtest)
+TARGET_LINK_LIBRARIES(basic_test GTest::gtest_main)
+TARGET_LINK_LIBRARIES(testB GTest::gtest_main)

--- a/_tests/_test_files/basic_test.cpp
+++ b/_tests/_test_files/basic_test.cpp
@@ -1,4 +1,4 @@
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
 #include <iostream>
 #include <iomanip>
 
@@ -21,9 +21,9 @@ using namespace std;
 bool basic_test(bool debug=false)
 {
   if (debug) {
-    cout << "\nbasic test...\n" << endl;
+    cout << "basic_test::basic_test()" << endl;
   }
-  return true;
+  return stub();
 }
 
 
@@ -34,12 +34,4 @@ TEST(BASIC_TEST, BasicTest)
 {
   bool success = basic_test(debug);
   EXPECT_EQ(success, true);
-}
-
-
-int main(int argc, char **argv)
-{
-  ::testing::InitGoogleTest(&argc, argv);
-  std::cout<<"\n\n----------running basic_test.cpp---------\n\n"<<std::endl;
-  return RUN_ALL_TESTS();
 }

--- a/_tests/_test_files/testB.cpp
+++ b/_tests/_test_files/testB.cpp
@@ -1,4 +1,4 @@
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
 #include <iostream>
 #include <iomanip>
 
@@ -15,9 +15,9 @@ using namespace std;
 bool test_stub(bool debug=false)
 {
   if (debug) {
-    cout << "testB:: test-sub() entering test_sub" << endl;
+    cout << "testB::test_stub()" << endl;
   }
-  return true;
+  return stub(); // returns true
 }
 
 //------------------------------------------------------------------------------
@@ -38,16 +38,8 @@ TEST(TEST_STUB, TestStub)
 }
 
 //------------------------------------------------------------------------------
-//@TODO: add more test sets to call test functions here:
+//@TODO: add more test cases to call test functions here:
 
 
 
 //------------------------------------------------------------------------------
-
-
-int main(int argc, char **argv)
-{
-  ::testing::InitGoogleTest(&argc, argv);
-  std::cout<<"\n\n----------running testB.cpp---------\n\n"<<std::endl;
-  return RUN_ALL_TESTS();
-}


### PR DESCRIPTION
- FetchContent is now using the "proper" method GIT_REPOSITORY & GIT_TAG vs URL
- New version of GTest which requires c++14
- CMake target for GTest is now consistent with modern CMake standards
- Using the gtest_main target means the test file no longer requires its own main function as GTest provides its own
- The source file "glob" now uses the keyword CONFIGURE_DEPENDS which makes it so directories are searched every time the project is built removing the need to reconfigure after adding a file